### PR TITLE
Add some decode commands to the stderr and stdout streams in the wrapper

### DIFF
--- a/mirpy/wrapper.py
+++ b/mirpy/wrapper.py
@@ -65,7 +65,7 @@ def mir_func(f, thefilter):
                                stderr=subprocess.PIPE)
         stdout, stderr = proc.communicate()
 
-        lines = stderr.split('\n')
+        lines = stderr.decode("utf-8", "ignore").splitlines()
         warns = []
         errors = []
         for l in lines:
@@ -84,7 +84,7 @@ def mir_func(f, thefilter):
 
         if proc.returncode != 0:
             raise MiriadError("\n".join(errors))
-        out = stdout.strip()
+        out = stdout.decode("utf-8", "ignore").strip()
         if thefilter is not None:
             return thefilter(out)
         return out


### PR DESCRIPTION
to prevent a Python 3 error from occurring while ensuring that any upper
level user code doesn't require modification.